### PR TITLE
Add speed dial touch control to nocturn-midi.json

### DIFF
--- a/config/nocturn-midi.json
+++ b/config/nocturn-midi.json
@@ -90,6 +90,16 @@
         "kind": "Cc",
         "num": 81
       }
+    }},
+    {"Single": {
+      "name": "speedDialTouch",
+      "ctrl_in_num": 82,
+      "ctrl_kind": {"OnOff": {"mode": "Momentary"}},
+      "midi": {
+        "channel": 0,
+        "kind": "Cc",
+        "num": 82
+      }
     }}
   ]
 }


### PR DESCRIPTION
_Kept getting a warning even though there is a config for the Speed Dial... After 10+ years of having this device on my desk I discovered the Speed Dial as an actual press-in button!_

Anyway, config for the Speed Dial touch sensor was missing. I assume the config is the same as all the other 8 touch dials.

I did not touch the `osc` configs, as I am not sure what `"midi_num"` needs to be.